### PR TITLE
Add Loom video overview to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,17 @@
   <img src="https://img.shields.io/badge/Django-092E20?style=flat-square&logo=django&logoColor=white" />
 </p>
 
-This project is a **portfolio showcase**, using the modern data engineering tech stack to generate synthetic data using Agent-based simulations.  
+This project is a **portfolio showcase**, using the modern data engineering tech stack to generate synthetic data using Agent-based simulations.
+
+---
+
+## 🎥 Video Overview
+
+<p align="center">
+  <a href="https://www.loom.com/share/1b57f0984ae24b4a9449bb21785dcfd5?sid=caf8957c-79d0-4d8a-a5a4-c8c15c246795" target="_blank" rel="noopener noreferrer">
+    <img src="https://cdn.loom.com/sessions/thumbnails/1b57f0984ae24b4a9449bb21785dcfd5-with-play.gif" alt="Watch the project overview video on Loom" width="640" />
+  </a>
+</p>
 
 ---
 


### PR DESCRIPTION
## Summary
- add a dedicated video overview section to the README
- link to the Loom recording with a clickable thumbnail preview

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e58e8bf000832e965156a6887b536f