### PR TITLE
Fix Loom embed in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,17 @@
   <img src="https://img.shields.io/badge/Django-092E20?style=flat-square&logo=django&logoColor=white" />
 </p>
 
-This project is a **portfolio showcase**, using the modern data engineering tech stack to generate synthetic data using Agent-based simulations.  
+This project is a **portfolio showcase**, using the modern data engineering tech stack to generate synthetic data using Agent-based simulations.
+
+---
+
+## 🎥 Video Overview
+
+<div align="center">
+
+[![Watch the project overview video on Loom](https://cdn.loom.com/sessions/thumbnails/1b57f0984ae24b4a9449bb21785dcfd5-with-play.gif)](https://www.loom.com/share/1b57f0984ae24b4a9449bb21785dcfd5)
+
+</div>
 
 ---
 


### PR DESCRIPTION
## Summary
- keep the README video overview section but render the Loom link with standard Markdown
- ensure the thumbnail links to the recording when viewed on GitHub

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e58e8bf000832e965156a6887b536f